### PR TITLE
🎨 Palette: Add ToolTips and screen reader support to icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-03-24 - Added tooltips to icon-only buttons in WPF
+**Learning:** WPF icon-only buttons need `ToolTip` and `AutomationProperties.Name` attributes, which act like ARIA labels for screen readers.
+**Action:** Always verify icon-only UI elements have both a visual ToolTip and an AutomationProperties.Name to ensure full accessibility in WPF.

--- a/ASCIIV.Player/PlayerWindow.xaml
+++ b/ASCIIV.Player/PlayerWindow.xaml
@@ -48,11 +48,15 @@
                         <Button Content="_" Click="MinimizeButton_Click"
                                 Style="{StaticResource TitleBarButtonStyle}" 
                                 Width="40" Height="30"
-                                Padding="0,-10,0,0"/>
+                                Padding="0,-10,0,0"
+                                ToolTip="Minimize"
+                                AutomationProperties.Name="Minimize"/>
 
                         <Button Content="X" Click="CloseButton_Click"
                                 Style="{StaticResource TitleBarCloseButtonStyle}" 
-                                Width="40" Height="30"/>
+                                Width="40" Height="30"
+                                ToolTip="Close"
+                                AutomationProperties.Name="Close"/>
                     </StackPanel>
                 </Grid>
             </Border>
@@ -101,7 +105,9 @@
                             <Button Grid.Column="0" x:Name="PlayPauseButton" 
                                     Style="{StaticResource GradientRoundedButtonStyle}"
                                     Width="80" Height="38" 
-                                    Click="PlayPauseButton_Click">
+                                    Click="PlayPauseButton_Click"
+                                    ToolTip="Play or Pause"
+                                    AutomationProperties.Name="Play or Pause">
                                 <Path x:Name="PlayButtonIcon"
                                       Data="{StaticResource PauseIcon}"
                                       Fill="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}"
@@ -115,7 +121,8 @@
                                         Height="38" Width="50"
                                         Click="SnapshotButton_Click"
                                         Margin="0,0,10,0"
-                                        ToolTip="Save Snapshot">
+                                        ToolTip="Save Snapshot"
+                                        AutomationProperties.Name="Save Snapshot">
                                     <Path Data="{StaticResource CameraIcon}"
                                           Fill="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}"
                                           Stretch="Uniform" Width="16" Height="16"/>
@@ -125,7 +132,9 @@
                                         Style="{StaticResource GradientRoundedButtonStyle}"
                                         Height="38" Width="50"
                                         Click="FullScreenButton_OnClick"
-                                        Margin="0,0,15,0">
+                                        Margin="0,0,15,0"
+                                        ToolTip="Toggle Full Screen"
+                                        AutomationProperties.Name="Toggle Full Screen">
                                     <Path x:Name="FullScreenIcon"
                                           Data="{StaticResource FullScreenIcon}"
                                           Fill="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}"

--- a/AsciiConverter/MainWindow.xaml
+++ b/AsciiConverter/MainWindow.xaml
@@ -51,11 +51,15 @@
                         <Button Content="_" Click="MinimizeButton_Click"
                                 Style="{StaticResource TitleBarButtonStyle}" 
                                 Width="40" Height="30" Margin="0,0,0,0"
-                                Padding="0,-10,0,0"/>
+                                Padding="0,-10,0,0"
+                                ToolTip="Minimize"
+                                AutomationProperties.Name="Minimize"/>
 
                         <Button Content="X" Click="CloseButton_Click"
                                 Style="{StaticResource TitleBarCloseButtonStyle}" 
-                                Width="40" Height="30"/>
+                                Width="40" Height="30"
+                                ToolTip="Close"
+                                AutomationProperties.Name="Close"/>
                     </StackPanel>
                 </Grid>
             </Border>
@@ -118,6 +122,7 @@
                         <Button x:Name="CustomColorButton" 
                                 Click="CustomColorButton_OnClick" Width="40" Height="40"
                                 ToolTip="Pick Custom Color"
+                                AutomationProperties.Name="Pick Custom Color"
                                 Margin="10,0"
                                 Style="{StaticResource GradientRoundedButtonStyle}">
                             <Path x:Name="PlayButtonIcon"


### PR DESCRIPTION
💡 What: Added `ToolTip` and `AutomationProperties.Name` properties to several icon-only buttons across the application interface.
🎯 Why: Icon-only buttons (like Minimize, Close, Play, Snapshot, Full Screen) are inaccessible to screen readers without descriptive text, and can be confusing to mouse users without a ToolTip. This enhances the usability for all users and specifically improves accessibility.
📸 Before/After: Visual change only evident on mouse hover (ToolTips appear).
♿ Accessibility: Improved screen reader support significantly by defining `AutomationProperties.Name` for controls that lacked text content.

---
*PR created automatically by Jules for task [4433851649777119197](https://jules.google.com/task/4433851649777119197) started by @MrSquirrely*